### PR TITLE
🐞 Fix order of style before precision

### DIFF
--- a/src/Copper/Copper.php
+++ b/src/Copper/Copper.php
@@ -89,11 +89,11 @@ class Copper
      */
     public static function decimal(?int $precision = null): string|bool
     {
-        if (false === is_null($precision)) {
-            self::$formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision);
-        }
         if (NumberFormatter::DECIMAL !== self::$style) {
             self::setStyle(NumberFormatter::DECIMAL);
+        }
+        if (false === is_null($precision)) {
+            self::$formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision);
         }
 
         return self::$formatter->format(self::$value);
@@ -184,11 +184,11 @@ class Copper
      */
     public static function unit(Unit $unit, bool $usePrefix = true, bool $useThrees = true, ?int $precision = null): string
     {
-        if (false === is_null($precision)) {
-            self::$formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision);
-        }
         if (NumberFormatter::DECIMAL !== self::$style) {
             self::setStyle(NumberFormatter::DECIMAL);
+        }
+        if (false === is_null($precision)) {
+            self::$formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision);
         }
 
         $value = self::$value;

--- a/tests/Unit/CopperTest.php
+++ b/tests/Unit/CopperTest.php
@@ -26,7 +26,8 @@ it('creates an instance with custom values', function () {
 });
 
 it('formats a number as decimal', function () {
-    Copper::create(1234.56, locale: 'en-GB');
+    Copper::create(1234.563, locale: 'en-GB');
+    Copper::setStyle(2);
     $result = Copper::decimal(2);
     expect($result)->toBe('1,234.56');
 });
@@ -63,6 +64,7 @@ it('formats a number as accounting currency', function () {
 
 it('formats a number with SI units and prefixes', function (float $value, string $output) {
     Copper::create($value);
+    Copper::setStyle(2);
     $result = Copper::unit(Unit::METRE);
     expect($result)->toBe($output);
 })->with([
@@ -87,6 +89,7 @@ it('formats a number with SI units and prefixes whilst using the non-multiples o
 
 it('formats a number with SI units and prefixes with specific precision', function () {
     Copper::create(123456);
+    Copper::setStyle(2);
     $result = Copper::unit(Unit::METRE, precision: 2);
     expect($result)->toBe('0.12 Mm');
 });


### PR DESCRIPTION

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

When using the newly added `unit()` function, the order of the style vs precision matters. Originally the precision was being set, and then the style. Under most conditions this doesn't lead to a problem.

However, if the style is incorrect for `unit()` then the `setStyle()` overrides the precision setting. As such the style needs to be set first, then the precision.

This PR fixes the order for `unit()` and `decimal()`.

### Related:

NA
